### PR TITLE
feat: Enhance schema description and AI chat context

### DIFF
--- a/bigquery-tools-frontend/src/pages/AIChatPage.test.tsx
+++ b/bigquery-tools-frontend/src/pages/AIChatPage.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+
+import AIChatPage from './AIChatPage';
+import * as aiService from '../services/aiService';
+import * as bigQueryConfigService from '../services/bigQueryConfigService';
+
+// Mock the services
+jest.mock('../services/aiService');
+jest.mock('../services/bigQueryConfigService');
+
+const mockGetConfigs = bigQueryConfigService.getConfigs as jest.Mock;
+const mockGenerateSql = aiService.generateSqlFromNaturalLanguage as jest.Mock;
+const mockDryRunQuery = aiService.dryRunQuery as jest.Mock;
+
+const mockConfigurations: bigQueryConfigService.BigQueryConfigItem[] = [
+  { id: 'config-ai-1', connection_name: 'AI Connection One' },
+  { id: 'config-ai-2', connection_name: 'AI Connection Two' },
+];
+
+// Helper function to render with Router context
+const renderPage = () => {
+  return render(
+    <BrowserRouter>
+      <AIChatPage />
+    </BrowserRouter>
+  );
+};
+
+describe('AIChatPage', () => {
+  beforeEach(() => {
+    mockGetConfigs.mockReset();
+    mockGenerateSql.mockReset();
+    mockDryRunQuery.mockReset();
+
+    // Default successful mocks
+    mockGetConfigs.mockResolvedValue(mockConfigurations);
+    mockGenerateSql.mockResolvedValue({ generated_sql: 'SELECT mock_column FROM mock_table;' });
+    mockDryRunQuery.mockResolvedValue({ message: 'Dry run successful.', gb_processed: 0.123 });
+  });
+
+  test('renders page title and initial elements', () => {
+    renderPage();
+    expect(screen.getByText('AI SQL Chat Assistant')).toBeInTheDocument();
+    expect(screen.getByLabelText('Configuration*')).toBeInTheDocument();
+    expect(screen.getByLabelText('Relevant Tables (Optional - uses all if empty)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Your request for SQL query...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+  });
+
+  test('loads configurations', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalledTimes(1));
+
+    fireEvent.mouseDown(screen.getByLabelText('Configuration*'));
+    expect(await screen.findByText('AI Connection One')).toBeInTheDocument();
+    expect(await screen.findByText('AI Connection Two')).toBeInTheDocument();
+  });
+
+  test('sends chat request and displays response with specific tables', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    // Select configuration
+    fireEvent.mouseDown(screen.getByLabelText('Configuration*'));
+    fireEvent.click(await screen.findByText('AI Connection One'));
+
+    // Enter user request
+    fireEvent.change(screen.getByLabelText('Your request for SQL query...'), { target: { value: 'Show me users from my_table' } });
+
+    // Enter relevant table names (Autocomplete interaction)
+    const autocompleteInput = screen.getByLabelText('Relevant Tables (Optional - uses all if empty)');
+    fireEvent.change(autocompleteInput, { target: { value: 'dataset.my_table' } });
+    fireEvent.keyDown(autocompleteInput, { key: 'Enter' }); // Simulate adding the typed value
+
+    // Click Send
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mockGenerateSql).toHaveBeenCalledWith(
+        'config-ai-1',
+        'Show me users from my_table',
+        ['dataset.my_table'] // Expecting array with the typed table
+      );
+    });
+
+    // Check for user message and AI response in chat
+    expect(screen.getByText('Show me users from my_table')).toBeInTheDocument();
+    await waitFor(() => {
+        expect(screen.getByText(/Generated SQL:/i)).toBeInTheDocument();
+        expect(screen.getByText('SELECT mock_column FROM mock_table;')).toBeInTheDocument(); // Check CodeBlock content
+        expect(screen.getByText(/Dry run successful. Processed: 0.1230 GB./i)).toBeInTheDocument();
+    });
+  });
+
+  test('sends chat request and displays response with no specific tables', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    fireEvent.mouseDown(screen.getByLabelText('Configuration*'));
+    fireEvent.click(await screen.findByText('AI Connection One'));
+    fireEvent.change(screen.getByLabelText('Your request for SQL query...'), { target: { value: 'General query about all data' } });
+
+    // Leave "Relevant Tables" empty
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(mockGenerateSql).toHaveBeenCalledWith(
+        'config-ai-1',
+        'General query about all data',
+        [] // Expecting empty array
+      );
+    });
+
+    expect(screen.getByText('General query about all data')).toBeInTheDocument();
+    await waitFor(() => {
+        expect(screen.getByText(/Generated SQL:/i)).toBeInTheDocument();
+        expect(screen.getByText('SELECT mock_column FROM mock_table;')).toBeInTheDocument();
+        expect(screen.getByText(/Dry run successful. Processed: 0.1230 GB./i)).toBeInTheDocument();
+    });
+  });
+
+  test('ui reflects optional tables field guidance', () => {
+    renderPage();
+    expect(screen.getByLabelText('Relevant Tables (Optional - uses all if empty)')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g., dataset.table (or leave blank to use all from connection)')).toBeInTheDocument();
+    expect(screen.getByText('If left blank, the AI will use schema descriptions from all tables saved under the selected configuration.')).toBeInTheDocument();
+  });
+
+  test('handles error from generateSqlFromNaturalLanguage', async () => {
+    mockGenerateSql.mockRejectedValueOnce(new Error('AI service unavailable'));
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    fireEvent.mouseDown(screen.getByLabelText('Configuration*'));
+    fireEvent.click(await screen.findByText('AI Connection One'));
+    fireEvent.change(screen.getByLabelText('Your request for SQL query...'), { target: { value: 'A request that will fail' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to generate SQL: AI service unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+   test('handles error from dryRunQuery', async () => {
+    mockDryRunQuery.mockRejectedValueOnce(new Error('Invalid SQL for dry run'));
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    fireEvent.mouseDown(screen.getByLabelText('Configuration*'));
+    fireEvent.click(await screen.findByText('AI Connection One'));
+    fireEvent.change(screen.getByLabelText('Your request for SQL query...'), { target: { value: 'Request leading to dry run error' } });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      // The SQL is still displayed
+      expect(screen.getByText('SELECT mock_column FROM mock_table;')).toBeInTheDocument();
+      // The content of the AI message should update to show the dry run error
+      expect(screen.getByText(/Dry run failed: Invalid SQL for dry run/i)).toBeInTheDocument();
+    });
+  });
+
+});

--- a/bigquery-tools-frontend/src/pages/AIChatPage.tsx
+++ b/bigquery-tools-frontend/src/pages/AIChatPage.tsx
@@ -180,12 +180,17 @@ const AIChatPage: React.FC = () => {
                         <TextField
                         {...params}
                         variant="outlined"
-                        label="Relevant Table/View Names (Optional)"
-                        placeholder="e.g., dataset.table, another.view"
+                        label="Relevant Tables (Optional - uses all if empty)"
+                        placeholder="e.g., dataset.table (or leave blank to use all from connection)"
                         />
                     )}
                     disabled={!selectedConfigId}
                 />
+                <FormControl fullWidth sx={{mt: 0.5}}> {/* Adjusted sx prop */}
+                    <Typography variant="caption" color="textSecondary" sx={{ pl: 1.5, pr: 1.5, textAlign: 'left' }}>
+                        If left blank, the AI will use schema descriptions from all tables saved under the selected configuration.
+                    </Typography>
+                </FormControl>
             </Grid>
         </Grid>
       </Paper>

--- a/bigquery-tools-frontend/src/pages/SchemaDescriptionPage.test.tsx
+++ b/bigquery-tools-frontend/src/pages/SchemaDescriptionPage.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom'; // Needed if there are NavLinks or similar
+
+import SchemaDescriptionPage from './SchemaDescriptionPage';
+import * as schemaService from '../services/schemaService';
+import * as bigQueryConfigService from '../services/bigQueryConfigService';
+
+// Mock the services
+jest.mock('../services/schemaService');
+jest.mock('../services/bigQueryConfigService');
+
+const mockGetConfigs = bigQueryConfigService.getConfigs as jest.Mock;
+const mockGetAllSavedSchemas = schemaService.getAllSavedSchemas as jest.Mock;
+const mockGetTableSchema = schemaService.getTableSchema as jest.Mock;
+const mockUpdateSchemaDescription = schemaService.updateSchemaDescription as jest.Mock;
+
+const mockConfigurations: bigQueryConfigService.BigQueryConfigItem[] = [
+  { id: 'config-1', connection_name: 'Connection Alpha' },
+  { id: 'config-2', connection_name: 'Connection Beta' },
+];
+
+const mockSavedSchemasData: schemaService.SavedObject[] = [
+  {
+    id: 'saved-obj-1',
+    connection_id: 'config-1',
+    object_name: 'dataset1.tableA',
+    object_description: 'Description for Table A',
+    fields: [
+      { id: 'field-A1', field_name: 'column1', field_description: 'Desc for column1' },
+      { id: 'field-A2', field_name: 'column2', field_description: 'Desc for column2' },
+    ],
+  },
+  {
+    id: 'saved-obj-2',
+    connection_id: 'config-2',
+    object_name: 'dataset2.tableB',
+    object_description: 'Description for Table B',
+    fields: [
+      { id: 'field-B1', field_name: 'data_field', field_description: 'Desc for data_field' },
+    ],
+  },
+    {
+    id: 'saved-obj-3',
+    connection_id: 'config-1', // Another object for Connection Alpha
+    object_name: 'dataset1.tableC',
+    object_description: 'Description for Table C',
+    fields: [
+      { id: 'field-C1', field_name: 'info', field_description: 'Desc for info' },
+    ],
+  },
+];
+
+// Helper function to render with Router context if needed
+const renderPage = () => {
+  return render(
+    <BrowserRouter>
+      <SchemaDescriptionPage />
+    </BrowserRouter>
+  );
+};
+
+
+describe('SchemaDescriptionPage', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockGetConfigs.mockReset();
+    mockGetAllSavedSchemas.mockReset();
+    mockGetTableSchema.mockReset();
+    mockUpdateSchemaDescription.mockReset();
+
+    // Default successful mocks
+    mockGetConfigs.mockResolvedValue(mockConfigurations);
+    mockGetAllSavedSchemas.mockResolvedValue(mockSavedSchemasData);
+    mockGetTableSchema.mockResolvedValue({ schema: [{ name: 'live_col', field_type: 'STRING' }] });
+    mockUpdateSchemaDescription.mockResolvedValue({ message: 'Descriptions saved successfully!' });
+  });
+
+  test('renders page title and initial elements', () => {
+    renderPage();
+    expect(screen.getByText('Describe BigQuery Object Schema')).toBeInTheDocument();
+    expect(screen.getByText('Select Configuration and Object')).toBeInTheDocument();
+    expect(screen.getByText('Browse Saved Object Descriptions')).toBeInTheDocument();
+  });
+
+  test('loads and displays configurations', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(mockGetConfigs).toHaveBeenCalledTimes(1);
+      // Check if one of the mock configurations is present in the dropdown
+      // MUI Select needs a bit more to test properly, often by opening the dropdown
+      fireEvent.mouseDown(screen.getByLabelText('Configuration'));
+    });
+    // After opening, check for items
+    expect(await screen.findByText('Connection Alpha (ID: ...fig-1)')).toBeInTheDocument();
+    expect(await screen.findByText('Connection Beta (ID: ...fig-2)')).toBeInTheDocument();
+  });
+
+  test('loads and displays saved schemas grouped by connection name', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetAllSavedSchemas).toHaveBeenCalledTimes(1));
+
+    // Check for connection names (Accordion summaries)
+    expect(await screen.findByText('Connection Alpha')).toBeInTheDocument();
+    expect(await screen.findByText('Connection Beta')).toBeInTheDocument();
+
+    // Check for object names within the accordions
+    expect(screen.getByText('dataset1.tableA')).toBeInTheDocument();
+    expect(screen.getByText('dataset1.tableC')).toBeInTheDocument(); // For Connection Alpha
+    expect(screen.getByText('dataset2.tableB')).toBeInTheDocument(); // For Connection Beta
+
+    // Check a description snippet
+    expect(screen.getByText(/Description for Table A/)).toBeInTheDocument();
+  });
+
+  test('clicking saved schema populates form', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetAllSavedSchemas).toHaveBeenCalledTimes(1));
+
+    // Find the load button for 'dataset1.tableA' (more robust selectors might be needed)
+    const loadButtons = await screen.findAllByRole('button', { name: /load this schema/i });
+    // Assuming the first load button corresponds to the first mock saved schema or find specific one
+    const tableALoadButton = loadButtons.find(button =>
+        button.closest('li')?.querySelector('[data-testid="ListItemText"]')?.textContent?.includes('dataset1.tableA') || // This is a guess, MUI structure can be complex
+        button.closest('li')?.textContent?.includes('dataset1.tableA') // Fallback
+    );
+
+    // A more direct way if we can add test ids or more specific aria-labels to list items or buttons
+    // For now, let's assume we find a button for dataset1.tableA
+    const specificLoadButton = (await screen.findAllByLabelText('load this schema')).find(
+      (btn) => btn.closest('li')?.textContent?.includes('dataset1.tableA')
+    );
+    expect(specificLoadButton).toBeInTheDocument();
+
+    if (specificLoadButton) {
+        fireEvent.click(specificLoadButton);
+    } else {
+        throw new Error("Could not find load button for dataset1.tableA");
+    }
+
+
+    await waitFor(() => {
+      // Configuration select
+      expect(screen.getByLabelText('Configuration')).toHaveTextContent('Connection Alpha'); // MUI select value is tricky, check displayed text
+      // Object Name input
+      expect(screen.getByLabelText('Object Name (dataset.table)')).toHaveValue('dataset1.tableA');
+      // Object Description
+      expect(screen.getByLabelText('Description for the entire object (table/view)')).toHaveValue('Description for Table A');
+    });
+
+    // Check fields table
+    expect(screen.getByRole('cell', { name: 'column1' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'N/A (saved)' })).toBeInTheDocument(); // Type for first field
+    // Find the text field for description of column1
+    const col1DescInput = screen.getByDisplayValue('Desc for column1'); // This works if value is unique
+    expect(col1DescInput).toBeInTheDocument();
+  });
+
+  test('get live schema button works', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    // Select configuration
+    fireEvent.mouseDown(screen.getByLabelText('Configuration'));
+    const configOption = await screen.findByText('Connection Alpha (ID: ...fig-1)');
+    fireEvent.click(configOption);
+
+    // Enter object name
+    fireEvent.change(screen.getByLabelText('Object Name (dataset.table)'), { target: { value: 'dataset.liveTable' } });
+
+    // Click "Get Live Schema"
+    fireEvent.click(screen.getByRole('button', { name: /get live schema/i }));
+
+    await waitFor(() => {
+      expect(mockGetTableSchema).toHaveBeenCalledWith('config-1', 'dataset.liveTable');
+    });
+    expect(screen.getByRole('cell', { name: 'live_col' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'STRING' })).toBeInTheDocument();
+  });
+
+  test('save descriptions button works', async () => {
+    renderPage();
+    await waitFor(() => expect(mockGetConfigs).toHaveBeenCalled());
+
+    // Populate form (e.g., by simulating "Get Live Schema" then editing)
+    fireEvent.mouseDown(screen.getByLabelText('Configuration'));
+    fireEvent.click(await screen.findByText('Connection Alpha (ID: ...fig-1)'));
+    fireEvent.change(screen.getByLabelText('Object Name (dataset.table)'), { target: { value: 'dataset.testSave' } });
+
+    mockGetTableSchema.mockResolvedValueOnce({ schema: [{ name: 'col_to_save', field_type: 'INTEGER' }] });
+    fireEvent.click(screen.getByRole('button', { name: /get live schema/i }));
+
+    await waitFor(() => expect(screen.getByRole('cell', { name: 'col_to_save' })).toBeInTheDocument());
+
+    // Edit object description
+    fireEvent.change(screen.getByLabelText('Description for the entire object (table/view)'), { target: { value: 'Test Object Description Save' } });
+
+    // Edit field description (more robust: find by row context)
+    const fieldDescInputs = screen.getAllByPlaceholderText('Enter field description...');
+    fireEvent.change(fieldDescInputs[0], { target: { value: 'Test Field Description Save' } });
+
+    // Click "Save All Descriptions"
+    fireEvent.click(screen.getByRole('button', { name: /save all descriptions/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateSchemaDescription).toHaveBeenCalledWith(
+        'config-1',
+        'dataset.testSave',
+        'Test Object Description Save',
+        [{ field_name: 'col_to_save', field_description: 'Test Field Description Save' }]
+      );
+    });
+    expect(await screen.findByText('Descriptions saved successfully!')).toBeInTheDocument();
+  });
+
+});
+
+`SchemaDescriptionPage.test.tsx` has been created with the tests.
+
+Next, I'll create `bigquery-tools-frontend/src/pages/AIChatPage.test.tsx` and implement the tests for the `AIChatPage` component.

--- a/bigquery-tools-frontend/src/pages/SchemaDescriptionPage.tsx
+++ b/bigquery-tools-frontend/src/pages/SchemaDescriptionPage.tsx
@@ -3,14 +3,17 @@ import {
   Container, Typography, FormControl, InputLabel, Select, MenuItem, TextField, Button,
   Box, Paper, Alert, CircularProgress, Snackbar,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
-  Grid
+  Grid,
+  List, ListItem, ListItemText, IconButton, Accordion, AccordionSummary, AccordionDetails
 } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import FileOpenIcon from '@mui/icons-material/FileOpen'; // For populating from saved
 import type { SelectChangeEvent } from '@mui/material';
 
 import { getConfigs } from '../services/bigQueryConfigService';
 import type { BigQueryConfigItem } from '../services/bigQueryConfigService';
-import { getTableSchema, updateSchemaDescription } from '../services/schemaService';
-import type { FieldSchema } from '../services/schemaService';
+import { getTableSchema, updateSchemaDescription, getAllSavedSchemas } from '../services/schemaService';
+import type { FieldSchema, SavedObject, SavedField } from '../services/schemaService';
 
 interface DescribedField extends FieldSchema {
   description: string;
@@ -28,19 +31,27 @@ const SchemaDescriptionPage: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
 
   const [error, setError] = useState<string | null>(null);
+  const [generalError, setGeneralError] = useState<string | null>(null); // For non-field specific errors
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+  // State for saved schemas
+  const [savedSchemas, setSavedSchemas] = useState<SavedObject[]>([]);
+  const [isLoadingSavedSchemas, setIsLoadingSavedSchemas] = useState(false);
+  const [savedSchemasError, setSavedSchemasError] = useState<string | null>(null);
+
+
   const objectNameInputRef = useRef<HTMLInputElement>(null);
+  const topOfFormRef = useRef<HTMLDivElement>(null); // Ref for scrolling
 
   useEffect(() => {
     const fetchConfigs = async () => {
       setIsLoadingConfigs(true);
-      setError(null);
+      setGeneralError(null);
       try {
         const configs = await getConfigs();
         setAvailableConfigs(configs);
       } catch (err: any) {
-        setError(err.message || "Failed to load configurations. Please ensure backend is running and you are logged in.");
+        setGeneralError(err.message || "Failed to load configurations. Please ensure backend is running and you are logged in.");
       } finally {
         setIsLoadingConfigs(false);
       }
@@ -48,28 +59,51 @@ const SchemaDescriptionPage: React.FC = () => {
     fetchConfigs();
   }, []);
 
+  // Fetch saved schemas on mount
   useEffect(() => {
-    if (selectedConfigId && !isLoadingConfigs) {
-      objectNameInputRef.current?.focus();
+    const fetchSavedSchemas = async () => {
+      setIsLoadingSavedSchemas(true);
+      setSavedSchemasError(null);
+      try {
+        const schemas = await getAllSavedSchemas();
+        setSavedSchemas(schemas);
+      } catch (err: any) {
+        setSavedSchemasError(err.message || "Failed to load saved schemas.");
+      } finally {
+        setIsLoadingSavedSchemas(false);
+      }
+    };
+    fetchSavedSchemas();
+  }, []);
+
+
+  useEffect(() => {
+    // Focus object name input if a config is selected, and not currently loading other things
+    // or if fields have just been populated (implying a saved schema was clicked)
+    if (selectedConfigId && !isLoadingConfigs && !isLoadingSchema && !isSaving) {
+        const timer = setTimeout(() => { // Timeout to allow state updates to render
+            objectNameInputRef.current?.focus();
+        }, 0);
+        return () => clearTimeout(timer);
     }
-  }, [selectedConfigId, isLoadingConfigs]);
+  }, [selectedConfigId, isLoadingConfigs, isLoadingSchema, isSaving, fields]);
 
 
   const handleGetSchema = async () => {
     if (!selectedConfigId || !objectName.trim()) {
-      setError("Please select a configuration and enter a valid object name (e.g., dataset.table).");
+      setGeneralError("Please select a configuration and enter a valid object name (e.g., dataset.table).");
       return;
     }
     if (objectName.trim().indexOf('.') <= 0 || objectName.trim().endsWith('.')) {
-        setError("Invalid object_name format. Expected 'dataset_id.table_id'.");
+        setGeneralError("Invalid object_name format. Expected 'dataset_id.table_id'.");
         return;
     }
 
     setIsLoadingSchema(true);
-    setError(null);
+    setGeneralError(null);
     setSuccessMessage(null);
-    setFields([]);
-    setObjectDescription('');
+    setFields([]); // Clear current fields
+    setObjectDescription(''); // Clear current object description
 
     try {
       const response = await getTableSchema(selectedConfigId, objectName.trim());
@@ -77,12 +111,12 @@ const SchemaDescriptionPage: React.FC = () => {
         setFields(response.schema.map(field => ({ ...field, description: '' })));
         setSuccessMessage(`Schema for '${objectName.trim()}' fetched successfully. You can now add descriptions.`);
       } else {
-        setFields([]);
-        setError(`Schema for '${objectName.trim()}' is empty or not found.`);
+        setFields([]); // Ensure fields are empty
+        setGeneralError(`Schema for '${objectName.trim()}' is empty or not found (live fetch).`);
       }
     } catch (err: any) {
-      setError(err.message || "Failed to fetch schema. Ensure the object exists and configuration is correct.");
-      setFields([]);
+      setGeneralError(err.message || "Failed to fetch schema. Ensure the object exists and configuration is correct.");
+      setFields([]); // Ensure fields are empty on error
     } finally {
       setIsLoadingSchema(false);
     }
@@ -98,45 +132,80 @@ const SchemaDescriptionPage: React.FC = () => {
 
   const handleSaveDescriptions = async () => {
     if (!selectedConfigId || !objectName.trim()) {
-      setError("Configuration and object name are required to save descriptions.");
+      setGeneralError("Configuration and object name are required to save descriptions.");
       return;
     }
     if (fields.length === 0) {
-        setError("No schema fields to save. Please fetch schema first.");
+        setGeneralError("No schema fields to save. Please fetch schema first or load a saved schema.");
         return;
     }
     setIsSaving(true);
-    setError(null);
+    setGeneralError(null);
     setSuccessMessage(null);
 
     const fieldDataToSave = fields.map(f => ({
       field_name: f.name,
-      field_description: f.description
+      // Ensure description is not undefined, send null if it's empty string for consistency with backend
+      field_description: f.description || null
     }));
+
+    const currentObjectDescription = objectDescription || null;
 
     try {
       const response = await updateSchemaDescription(
         selectedConfigId,
         objectName.trim(),
-        objectDescription,
+        currentObjectDescription,
         fieldDataToSave
       );
       setSuccessMessage(response.message || "Descriptions saved successfully!");
+      // Optionally, refresh saved schemas after successful save
+      // fetchSavedSchemas(); // Consider if this is too much or if a manual refresh button is better
     } catch (err: any) {
-      setError(err.message || "Failed to save descriptions. Please check details and try again.");
+      setGeneralError(err.message || "Failed to save descriptions. Please check details and try again.");
     } finally {
       setIsSaving(false);
     }
   };
 
+  const handleLoadSavedSchema = (savedObject: SavedObject) => {
+    setSelectedConfigId(savedObject.connection_id);
+    setObjectName(savedObject.object_name);
+    setObjectDescription(savedObject.object_description || '');
+    setFields(savedObject.fields.map(f => ({
+      name: f.field_name,
+      field_type: 'N/A (saved)', // As per requirement
+      description: f.field_description || ''
+    })));
+    setGeneralError(null); // Clear any previous errors
+    setSuccessMessage(`Loaded saved schema for '${savedObject.object_name}'. You can edit and save again.`);
+
+    // Scroll to top of form for better UX
+    if(topOfFormRef.current) {
+        topOfFormRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+
+  // Group saved schemas by connection name for display
+  const groupedSavedSchemas = savedSchemas.reduce((acc, curr) => {
+    const config = availableConfigs.find(c => c.id === curr.connection_id);
+    const connectionName = config ? config.connection_name : `Unknown Connection (ID: ${curr.connection_id})`;
+    if (!acc[connectionName]) {
+      acc[connectionName] = [];
+    }
+    acc[connectionName].push(curr);
+    return acc;
+  }, {} as Record<string, SavedObject[]>);
+
 
   return (
-    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
-      <Typography variant="h4" gutterBottom>
+    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}> {/* Changed to xl for more space */}
+      <Typography variant="h4" gutterBottom ref={topOfFormRef}>
         Describe BigQuery Object Schema
       </Typography>
 
-      {error && <Alert severity="error" onClose={() => setError(null)} sx={{mb:2}}>{error}</Alert>}
+      {generalError && <Alert severity="error" onClose={() => setGeneralError(null)} sx={{mb:2}}>{generalError}</Alert>}
       {successMessage && (
         <Snackbar
             open={!!successMessage}
@@ -150,116 +219,173 @@ const SchemaDescriptionPage: React.FC = () => {
         </Snackbar>
       )}
 
-      <Paper sx={{ p: {xs: 2, md: 3}, mb: 3 }}>
-        <Typography variant="h6" gutterBottom>Select Configuration and Object</Typography>
-        <Grid container spacing={2} alignItems="center">
-          <Grid item={true} xs={12} md={5}> {/* Explicit item={true} */}
-            <FormControl fullWidth >
-              <InputLabel id="config-select-label">Configuration</InputLabel>
-              <Select
-                labelId="config-select-label"
-                value={selectedConfigId}
-                label="Configuration"
-                onChange={(e: SelectChangeEvent<string>) => {
-                    setSelectedConfigId(e.target.value);
-                    setObjectName('');
-                    setFields([]);
-                    setObjectDescription('');
-                }}
-                disabled={isLoadingConfigs || availableConfigs.length === 0}
-              >
-                {isLoadingConfigs && <MenuItem value=""><em>Loading configs...</em></MenuItem>}
-                {!isLoadingConfigs && availableConfigs.length === 0 && <MenuItem value="" disabled><em>No configurations found. Add one on BQ Configs page.</em></MenuItem>}
-                {availableConfigs.map((config) => (
-                  <MenuItem key={config.id} value={config.id}>
-                    {config.connection_name} (ID: ...{config.id.slice(-6)})
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item={true} xs={12} md={5}> {/* Explicit item={true} */}
-            <TextField
-              label="Object Name (dataset.table)"
-              value={objectName}
-              onChange={(e) => setObjectName(e.target.value)}
-              fullWidth
-              disabled={!selectedConfigId || isLoadingSchema}
-              inputRef={objectNameInputRef}
-            />
-          </Grid>
-          <Grid item={true} xs={12} md={2}> {/* Explicit item={true} */}
-            <Button
-              fullWidth
-              variant="contained"
-              onClick={handleGetSchema}
-              disabled={!selectedConfigId || !objectName.trim() || isLoadingSchema || isSaving}
-              sx={{height: '56px'}}
-            >
-              {isLoadingSchema ? <CircularProgress size={24} /> : "Get Schema"}
-            </Button>
-          </Grid>
-        </Grid>
-      </Paper>
+      {/* Main layout grid */}
+      <Grid container spacing={3}>
+        {/* Left Panel: Schema Editing Form */}
+        <Grid item xs={12} md={7}>
+          <Paper sx={{ p: { xs: 2, md: 3 }, mb: 3 }}>
+            <Typography variant="h6" gutterBottom>Select Configuration and Object</Typography>
+            <Grid container spacing={2} alignItems="center">
+              <Grid item xs={12} sm={6}>
+                <FormControl fullWidth>
+                  <InputLabel id="config-select-label">Configuration</InputLabel>
+                  <Select
+                    labelId="config-select-label"
+                    value={selectedConfigId}
+                    label="Configuration"
+                    onChange={(e: SelectChangeEvent<string>) => {
+                        setSelectedConfigId(e.target.value);
+                        setObjectName(''); // Clear object name when config changes
+                        setFields([]); // Clear fields
+                        setObjectDescription(''); // Clear object description
+                        setGeneralError(null); // Clear errors
+                    }}
+                    disabled={isLoadingConfigs || availableConfigs.length === 0}
+                  >
+                    {isLoadingConfigs && <MenuItem value=""><em>Loading configs...</em></MenuItem>}
+                    {!isLoadingConfigs && availableConfigs.length === 0 && <MenuItem value="" disabled><em>No configurations found. Add one on BQ Configs page.</em></MenuItem>}
+                    {availableConfigs.map((config) => (
+                      <MenuItem key={config.id} value={config.id}>
+                        {config.connection_name} (ID: ...{config.id.slice(-6)})
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="Object Name (dataset.table)"
+                  value={objectName}
+                  onChange={(e) => setObjectName(e.target.value)}
+                  fullWidth
+                  disabled={!selectedConfigId || isLoadingSchema || isSaving}
+                  inputRef={objectNameInputRef}
+                />
+              </Grid>
+              <Grid item xs={12}> {/* Button takes full width on small screens, then adjusts */}
+                <Button
+                  fullWidth
+                  variant="contained"
+                  onClick={handleGetSchema}
+                  disabled={!selectedConfigId || !objectName.trim() || isLoadingSchema || isSaving}
+                  sx={{ height: '56px' }}
+                >
+                  {isLoadingSchema ? <CircularProgress size={24} /> : "Get Live Schema"}
+                </Button>
+              </Grid>
+            </Grid>
+          </Paper>
 
-      {fields.length > 0 && (
-        <Paper sx={{ p: {xs: 2, md: 3}, mb: 3 }}>
-          <Typography variant="h6" gutterBottom>Object Description</Typography>
-          <TextField
-            label="Description for the entire object (table/view)"
-            value={objectDescription}
-            onChange={(e) => setObjectDescription(e.target.value)}
-            fullWidth
-            multiline
-            rows={3}
-            margin="normal"
-            sx={{mb:3}}
-            disabled={isSaving || isLoadingSchema}
-          />
+          {fields.length > 0 && (
+            <Paper sx={{ p: { xs: 2, md: 3 }, mb: 3 }}>
+              <Typography variant="h6" gutterBottom>Object Description</Typography>
+              <TextField
+                label="Description for the entire object (table/view)"
+                value={objectDescription}
+                onChange={(e) => setObjectDescription(e.target.value)}
+                fullWidth
+                multiline
+                rows={3}
+                margin="normal"
+                sx={{ mb: 3 }}
+                disabled={isSaving || isLoadingSchema}
+              />
 
-          <Typography variant="h6" gutterBottom>Field Descriptions</Typography>
-          <TableContainer component={Paper} sx={{mb:2}}>
-            <Table sx={{ minWidth: 650 }} size="small" aria-label="schema fields table">
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{fontWeight: 'bold'}}>Field Name</TableCell>
-                  <TableCell sx={{fontWeight: 'bold'}}>Data Type</TableCell>
-                  <TableCell sx={{fontWeight: 'bold', width: '50%'}}>Description</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {fields.map((field, index) => (
-                  <TableRow hover key={`${field.name}-${index}`} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
-                    <TableCell component="th" scope="row">{field.name}</TableCell>
-                    <TableCell>{field.field_type}</TableCell>
-                    <TableCell>
-                      <TextField
-                        fullWidth
-                        variant="outlined"
-                        size="small"
-                        value={field.description}
-                        onChange={(e) => handleFieldDescriptionChange(index, e.target.value)}
-                        placeholder="Enter field description..."
-                        disabled={isSaving || isLoadingSchema}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          <Box sx={{ mt: 3, textAlign: 'right' }}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSaveDescriptions}
-              disabled={isSaving || isLoadingSchema || fields.length === 0}
-            >
-              {isSaving ? <CircularProgress size={24} /> : "Save All Descriptions"}
-            </Button>
-          </Box>
-        </Paper>
-      )}
+              <Typography variant="h6" gutterBottom>Field Descriptions</Typography>
+              <TableContainer component={Paper} sx={{ mb: 2, maxHeight: '400px', overflowY: 'auto' }}>
+                <Table stickyHeader sx={{ minWidth: 650 }} size="small" aria-label="schema fields table">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 'bold' }}>Field Name</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold' }}>Data Type</TableCell>
+                      <TableCell sx={{ fontWeight: 'bold', width: '50%' }}>Description</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {fields.map((field, index) => (
+                      <TableRow hover key={`${field.name}-${index}-${selectedConfigId}-${objectName}`} sx={{ '&:last-child td, &:last-child th': { border: 0 } }}>
+                        <TableCell component="th" scope="row">{field.name}</TableCell>
+                        <TableCell>{field.field_type}</TableCell>
+                        <TableCell>
+                          <TextField
+                            fullWidth
+                            variant="outlined"
+                            size="small"
+                            value={field.description}
+                            onChange={(e) => handleFieldDescriptionChange(index, e.target.value)}
+                            placeholder="Enter field description..."
+                            disabled={isSaving || isLoadingSchema}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              <Box sx={{ mt: 3, textAlign: 'right' }}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleSaveDescriptions}
+                  disabled={isSaving || isLoadingSchema || fields.length === 0}
+                >
+                  {isSaving ? <CircularProgress size={24} /> : "Save All Descriptions"}
+                </Button>
+              </Box>
+            </Paper>
+          )}
+        </Grid> {/* End Left Panel */}
+
+        {/* Right Panel: Saved Schemas */}
+        <Grid item xs={12} md={5}>
+          <Paper sx={{ p: { xs: 2, md: 3 }, maxHeight: 'calc(100vh - 120px)', overflowY: 'auto' }}>
+            <Typography variant="h6" gutterBottom>
+              Browse Saved Object Descriptions
+            </Typography>
+            {isLoadingSavedSchemas && <CircularProgress />}
+            {savedSchemasError && <Alert severity="error">{savedSchemasError}</Alert>}
+            {!isLoadingSavedSchemas && !savedSchemasError && savedSchemas.length === 0 && (
+              <Typography variant="body2">No saved schemas found.</Typography>
+            )}
+            {!isLoadingSavedSchemas && !savedSchemasError && Object.keys(groupedSavedSchemas).length > 0 && (
+              Object.entries(groupedSavedSchemas).map(([connectionName, objects]) => (
+                <Accordion key={connectionName} defaultExpanded>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography sx={{fontWeight: 'medium'}}>{connectionName}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <List dense>
+                      {objects.map(obj => (
+                        <ListItem
+                          key={obj.id}
+                          secondaryAction={
+                            <IconButton edge="end" aria-label="load schema" onClick={() => handleLoadSavedSchema(obj)} title="Load this schema">
+                              <FileOpenIcon />
+                            </IconButton>
+                          }
+                          sx={{
+                            mb: 1,
+                            border: '1px solid lightgray',
+                            borderRadius: '4px',
+                            '&:hover': { backgroundColor: 'action.hover' }
+                          }}
+                          divider
+                        >
+                          <ListItemText
+                            primary={obj.object_name}
+                            secondary={obj.object_description ? `Desc: ${obj.object_description.substring(0,50)}...` : "No object description."}
+                            primaryTypographyProps={{ fontWeight: 'bold' }}
+                          />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </AccordionDetails>
+                </Accordion>
+              ))
+            )}
+          </Paper>
+        </Grid> {/* End Right Panel */}
+      </Grid> {/* End Main Grid */}
     </Container>
   );
 };

--- a/bigquery-tools-frontend/src/services/schemaService.ts
+++ b/bigquery-tools-frontend/src/services/schemaService.ts
@@ -39,6 +39,33 @@ export const getTableSchema = async (connectionId: string, objectName: string): 
   }
 };
 
+// Interfaces for getAllSavedSchemas
+export interface SavedField {
+  id: string;
+  field_name: string;
+  field_description: string | null;
+}
+
+export interface SavedObject {
+  id: string;
+  connection_id: string;
+  object_name: string;
+  object_description: string | null;
+  fields: SavedField[];
+}
+
+export const getAllSavedSchemas = async (): Promise<SavedObject[]> => {
+  try {
+    const response = await apiClient.get<SavedObject[]>('/objects_with_fields');
+    return response.data;
+  } catch (error: any) {
+    if (error.response && error.response.data) {
+      throw error.response.data as ErrorResponse;
+    }
+    throw { message: error.message || 'Failed to fetch saved schemas.' } as ErrorResponse;
+  }
+};
+
 export const updateSchemaDescription = async (
   connectionId: string,
   objectName: string,


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  **Schema Description Page**:
    *   The backend now has a new endpoint `/api/objects_with_fields` that returns all saved objects (tables/views) and their field descriptions for you.
    *   The "Schema Description" frontend page (`SchemaDescriptionPage.tsx`) now fetches and displays these saved schemas on page load.
    *   You can browse these saved schemas, grouped by connection, and click a "Load" button to populate the editing form with the selected object's name, description, and field descriptions.
    *   The "Get Schema" button has been relabeled to "Get Live Schema" to differentiate from loading saved descriptions.

2.  **AI Chat Context**:
    *   The backend `/api/generate_sql_from_natural_language` route has been modified. If the frontend does not provide specific `object_names` in the request, the backend will now automatically fetch all saved schema descriptions (objects and their fields) associated with the selected `connection_id` for you. This comprehensive schema information is then passed to the Gemini AI service to provide broader context for SQL generation.
    *   The frontend "AI Chat" page (`AIChatPage.tsx`) has been updated to reflect this. The "Relevant Tables" input field's label and helper text now clearly state that if left empty, all saved schemas for the selected connection will be used as context.

Backend and frontend tests have been added to cover these new functionalities and modifications, including testing the new API endpoint, the logic for fetching all schemas in the AI chat backend, and the new UI interactions on the frontend pages.