### PR TITLE
Fix: Correct TypeScript errors in MainLayout.test.tsx

### DIFF
--- a/bigquery-tools-frontend/src/layouts/MainLayout.test.tsx
+++ b/bigquery-tools-frontend/src/layouts/MainLayout.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react'; // Import type
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from '../theme'; // Adjusted import
+// Removed static import: import MainLayout from './MainLayout';
+
+// Mock the authService logout function
+jest.mock('../services/authService', () => ({
+  logout: jest.fn(),
+}));
+
+// Helper for wrapping component with providers
+const AllTheProviders: React.FC<{children: React.ReactNode}> = ({ children }) => {
+  return (
+    <ThemeProvider theme={theme}> {/* Using theme directly */}
+      <MemoryRouter initialEntries={['/']}>
+        {children}
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+};
+
+const customRender = (ui: React.ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: AllTheProviders, ...options });
+
+
+describe('MainLayout - Basic Rendering (Mobile Default)', () => {
+  beforeEach(() => {
+    jest.resetModules(); // Reset modules to ensure fresh mocks for useMediaQuery
+    jest.mock('@mui/material', () => ({
+      ...jest.requireActual('@mui/material'),
+      useMediaQuery: jest.fn().mockReturnValue(false), // Default to mobile for these basic tests
+    }));
+  });
+
+  afterEach(() => {
+    jest.unmock('@mui/material');
+  });
+
+  test('renders AppBar title', async () => {
+    const MockedMainLayout = (await import('./MainLayout')).default;
+    customRender(<MockedMainLayout />);
+    expect(screen.getByText(/BigQuery Tools/i)).toBeInTheDocument();
+  });
+
+  test('initially does not show drawer items and menu button is visible', async () => {
+    const MockedMainLayout = (await import('./MainLayout')).default;
+    customRender(<MockedMainLayout />);
+    // queryByText is good here as it won't throw if not found / not visible
+    // Depending on Drawer's ModalProps->keepMounted, items might be in DOM but not visible.
+    expect(screen.queryByText('BQ Configs')).not.toBeVisible();
+    expect(screen.getByRole('button', { name: /open drawer/i })).toBeVisible();
+  });
+});
+
+describe('MainLayout - Permanent Drawer (Desktop)', () => {
+  beforeAll(() => {
+    jest.resetModules();
+    // Mock useMediaQuery to return true for desktop for all tests in this describe block
+    jest.mock('@mui/material', () => ({
+      ...jest.requireActual('@mui/material'),
+      useMediaQuery: jest.fn().mockReturnValue(true),
+    }));
+  });
+
+  afterAll(() => {
+    jest.unmock('@mui/material'); // Clean up the mock
+  });
+
+
+  test('renders navigation links in permanent drawer and hides menu button', async () => {
+    const MockedMainLayout = (await import('./MainLayout')).default;
+    customRender(<MockedMainLayout />);
+    expect(screen.getByText(/Home/i)).toBeVisible();
+    expect(screen.getByText(/BQ Configs/i)).toBeVisible();
+    expect(screen.getByText(/Schema Desc/i)).toBeVisible();
+    expect(screen.getByText(/AI Chat/i)).toBeVisible();
+
+    // The menu button should be hidden on desktop (not even in the DOM due to sx prop)
+    expect(screen.queryByRole('button', { name: /open drawer/i })).not.toBeInTheDocument();
+  });
+});
+
+
+describe('MainLayout - Temporary Drawer (Mobile/Tablet)', () => {
+  beforeAll(() => {
+    jest.resetModules();
+    // Mock useMediaQuery to return false for mobile for all tests in this describe block
+    jest.mock('@mui/material', () => ({
+      ...jest.requireActual('@mui/material'),
+      useMediaQuery: jest.fn().mockReturnValue(false),
+    }));
+  });
+
+   afterAll(() => {
+    jest.unmock('@mui/material'); // Clean up the mock
+  });
+
+  test('shows menu button, and toggles drawer visibility', async () => {
+    const MockedMainLayout = (await import('./MainLayout')).default;
+    customRender(<MockedMainLayout />);
+
+    const menuButton = screen.getByRole('button', { name: /open drawer/i });
+    expect(menuButton).toBeInTheDocument();
+    expect(menuButton).toBeVisible();
+
+    // Initially, drawer items should not be visible if keepMounted is true, or not in DOM
+    expect(screen.queryByText('Home')).not.toBeVisible();
+
+    // Open the drawer
+    await act(async () => {
+        fireEvent.click(menuButton);
+    });
+
+    // Now drawer items should be visible
+    expect(screen.getByText(/Home/i)).toBeVisible();
+    expect(screen.getByText(/BQ Configs/i)).toBeVisible();
+
+    // Test closing by clicking an item (e.g., Home)
+    const homeButtonInDrawer = screen.getByText(/Home/i);
+    await act(async () => {
+        fireEvent.click(homeButtonInDrawer);
+    });
+
+    // Drawer items should be hidden again
+    expect(screen.queryByText('BQ Configs')).not.toBeVisible();
+  });
+});

--- a/bigquery-tools-frontend/src/layouts/MainLayout.tsx
+++ b/bigquery-tools-frontend/src/layouts/MainLayout.tsx
@@ -6,42 +6,111 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-// import IconButton from '@mui/material/IconButton'; // Removed as unused
 import Tooltip from '@mui/material/Tooltip';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import CssBaseline from '@mui/material/CssBaseline';
+import Divider from '@mui/material/Divider';
+import MenuIcon from '@mui/icons-material/Menu';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+
 
 // Import icons if you want to use them for smaller screens
-// import SettingsIcon from '@mui/icons-material/Settings';
-// import DescriptionIcon from '@mui/icons-material/Description';
-// import SmartToyIcon from '@mui/icons-material/SmartToy';
+import HomeIcon from '@mui/icons-material/Home';
+import StorageIcon from '@mui/icons-material/Storage'; // For BQ Configs
+import DescriptionIcon from '@mui/icons-material/Description'; // For Schema Desc
+import ChatIcon from '@mui/icons-material/Chat'; // For AI Chat
+// import SmartToyIcon from '@mui/icons-material/SmartToy'; // Alternative for AI Chat
 
-const NavButton = (props: {to: string, children: React.ReactNode, title: string }) => (
-    <Tooltip title={props.title}>
-        <Button
-            color="inherit"
-            component={RouterLink}
-            to={props.to}
-            sx={{
-                mr: 1,
-            }}
-        >
-            {props.children}
-        </Button>
-    </Tooltip>
-);
-
+const drawerWidth = 240;
 
 const MainLayout: React.FC = () => {
   const navigate = useNavigate();
+  const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
   const handleLogout = () => {
     logout();
     navigate('/login');
   };
 
+  const handleDrawerToggle = () => {
+    if (!isDesktop) {
+      setIsDrawerOpen(!isDrawerOpen);
+    }
+  };
+
+  const drawerContent = (
+    <>
+      {isDesktop && <Toolbar />}{/* Spacer for permanent drawer */}
+      {isDesktop && <Divider />}
+      <List>
+        <Tooltip title="Home">
+          <ListItem button component={RouterLink} to="/" onClick={handleDrawerToggle}>
+            <ListItemIcon>
+              <HomeIcon />
+            </ListItemIcon>
+            <ListItemText primary="Home" />
+          </ListItem>
+        </Tooltip>
+        <Tooltip title="BigQuery Configurations">
+          <ListItem button component={RouterLink} to="/bigquery-configs" onClick={handleDrawerToggle}>
+            <ListItemIcon>
+              <StorageIcon />
+            </ListItemIcon>
+            <ListItemText primary="BQ Configs" />
+          </ListItem>
+        </Tooltip>
+        <Tooltip title="Schema Descriptions">
+          <ListItem button component={RouterLink} to="/schema-description" onClick={handleDrawerToggle}>
+            <ListItemIcon>
+              <DescriptionIcon />
+            </ListItemIcon>
+            <ListItemText primary="Schema Desc" />
+          </ListItem>
+        </Tooltip>
+        <Tooltip title="AI SQL Chat Assistant">
+          <ListItem button component={RouterLink} to="/ai-chat" onClick={handleDrawerToggle}>
+            <ListItemIcon>
+              <ChatIcon />
+            </ListItemIcon>
+            <ListItemText primary="AI Chat" />
+          </ListItem>
+        </Tooltip>
+      </List>
+    </>
+  );
+
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <AppBar position="static">
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <CssBaseline />
+      <AppBar
+        position="fixed"
+        sx={{
+          width: { md: `calc(100% - ${drawerWidth}px)` },
+          ml: { md: `${drawerWidth}px` },
+          // transition: theme.transitions.create(['margin', 'width'], { // Optional
+          //   easing: theme.transitions.easing.sharp,
+          //   duration: theme.transitions.duration.leavingScreen,
+          // }),
+        }}
+      >
         <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            edge="start"
+            onClick={handleDrawerToggle}
+            sx={{ mr: 2, display: { md: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
           <Typography
             variant="h6"
             component={RouterLink}
@@ -50,25 +119,47 @@ const MainLayout: React.FC = () => {
           >
             BigQuery Tools
           </Typography>
-
-          <NavButton to="/bigquery-configs" title="BigQuery Configurations">
-            BQ Configs
-          </NavButton>
-          <NavButton to="/schema-description" title="Schema Descriptions">
-            Schema Desc
-          </NavButton>
-          <NavButton to="/ai-chat" title="AI SQL Chat Assistant">
-            AI Chat
-          </NavButton>
-
           <Tooltip title="Logout">
             <Button color="inherit" onClick={handleLogout}>
-                Logout
+              Logout
             </Button>
           </Tooltip>
         </Toolbar>
       </AppBar>
-      <Box component="main" sx={{ flexGrow: 1, p: {xs: 1, sm: 2, md: 3} /* Responsive padding */ }}>
+      <Box
+        component="nav"
+        sx={{ width: { md: drawerWidth }, flexShrink: { md: 0 } }}
+        aria-label="mailbox folders"
+      >
+        <Drawer
+          variant={isDesktop ? 'permanent' : 'temporary'}
+          open={isDesktop ? true : isDrawerOpen}
+          onClose={handleDrawerToggle} // Only used for temporary variant
+          ModalProps={{
+            keepMounted: true, // Better open performance on mobile.
+          }}
+          sx={{
+            display: { xs: 'block', md: 'block' },
+            '& .MuiDrawer-paper': {
+              boxSizing: 'border-box',
+              width: drawerWidth,
+              // borderRight: '1px solid rgba(0, 0, 0, 0.12)' // Optional
+            },
+          }}
+        >
+          {drawerContent}
+        </Drawer>
+      </Box>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: 3,
+          width: { md: `calc(100% - ${drawerWidth}px)` },
+          // marginLeft handled by AppBar and Drawer structure for 'md' up
+        }}
+      >
+        <Toolbar /> {/* Necessary for content to be below app bar */}
         <Outlet />
       </Box>
       {/* Optional: Footer ... */}


### PR DESCRIPTION
Addresses TypeScript errors TS1484 and TS6133 in the test file for the MainLayout component that caused the build to fail.

- `RenderOptions` is now imported as a type-only import.
- Removed unused static `MainLayout` import as dynamic imports are used within test suites.

This commit ensures the frontend build completes successfully after the recent UI/UX modernization. The core changes from the previous commit (modernized admin panel layout) are retained.