### PR TITLE
feat: Add SQL formatting and copy button to AI Chat

### DIFF
--- a/bigquery-tools-frontend/package-lock.json
+++ b/bigquery-tools-frontend/package-lock.json
@@ -10,12 +10,13 @@
       "dependencies": {
         "@emotion/react": "^11.10.0",
         "@emotion/styled": "^11.10.0",
-        "@mui/icons-material": "^5.11.0",
+        "@mui/icons-material": "^5.17.1",
         "@mui/material": "^5.11.0",
         "axios": "^1.9.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.1"
+        "react-router-dom": "^7.6.1",
+        "sql-formatter": "^15.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2576,8 +2577,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2828,6 +2828,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2983,6 +2988,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -4311,6 +4321,11 @@
         "node": "*"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4348,6 +4363,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -4640,6 +4676,23 @@
         }
       ]
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -4762,6 +4815,14 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/reusify": {
@@ -4944,6 +5005,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.6.2.tgz",
+      "integrity": "sha512-ZjqOfJGuB97UeHzTJoTbadlM0h9ynehtSTHNUbGfXR4HZ4rCIoD2oIW91W+A5oE76k8hl0Uz5GD8Sx3Pt9Xa3w==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
       }
     },
     "node_modules/stack-utils": {

--- a/bigquery-tools-frontend/package.json
+++ b/bigquery-tools-frontend/package.json
@@ -14,12 +14,13 @@
   "dependencies": {
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
-    "@mui/icons-material": "^5.11.0",
+    "@mui/icons-material": "^5.17.1",
     "@mui/material": "^5.11.0",
     "axios": "^1.9.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.1"
+    "react-router-dom": "^7.6.1",
+    "sql-formatter": "^15.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/bigquery-tools-frontend/src/components/CodeBlock.tsx
+++ b/bigquery-tools-frontend/src/components/CodeBlock.tsx
@@ -1,29 +1,68 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Snackbar from '@mui/material/Snackbar';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { format } from 'sql-formatter';
 
 interface CodeBlockProps {
   sql: string;
 }
 
-const CodeBlock: React.FC<CodeBlockProps> = ({ sql }) => (
-  <Paper elevation={1} sx={{
-    p: 1.5,
-    mt: 1,
+const CodeBlock: React.FC<CodeBlockProps> = ({ sql }) => {
+  const [showCopyMessage, setShowCopyMessage] = useState(false);
+  const formattedSql = format(sql, { language: 'bigquery', keywordCase: 'lower' });
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(formattedSql);
+      setShowCopyMessage(true);
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+  };
+
+  return (
+    <Paper elevation={1} sx={{
+      p: 1.5,
+      mt: 1,
     backgroundColor: (theme) => theme.palette.mode === 'dark' ? 'grey.800' : 'grey.100',
     color: (theme) => theme.palette.text.primary,
     overflowX: 'auto',
-    border: (theme) => `1px solid ${theme.palette.divider}`
+      border: (theme) => `1px solid ${theme.palette.divider}`,
+      position: 'relative', // For positioning the copy button
   }}>
+      <IconButton
+        onClick={handleCopy}
+        sx={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          color: (theme) => theme.palette.action.active,
+        }}
+        aria-label="copy sql to clipboard"
+      >
+        <ContentCopyIcon />
+      </IconButton>
     <Typography component="pre" sx={{
       whiteSpace: 'pre-wrap',
       wordBreak: 'break-all', // Ensure long strings without spaces wrap
+        paddingRight: '40px', // Ensure text does not overlap with copy button
       fontFamily: 'monospace',
       fontSize: '0.875rem'
     }}>
-      {sql}
+      {formattedSql}
     </Typography>
+    <Snackbar
+      open={showCopyMessage}
+      autoHideDuration={2000}
+      onClose={() => setShowCopyMessage(false)}
+      message="Copied!"
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    />
   </Paper>
-);
+  );
+};
 
 export default CodeBlock;


### PR DESCRIPTION
This commit introduces two main improvements to the AI SQL Chat Assistant:

1.  **SQL Code Formatting:**
    - SQL code generated by me is now formatted for better readability.
    - Keywords are displayed in lowercase, and queries are properly indented with line breaks.
    - This is achieved using the `sql-formatter` library in the `CodeBlock.tsx` component.

2.  **Copy SQL Button:**
    - A copy button (using a content copy icon) has been added to each SQL code block.
    - Clicking this button copies the formatted SQL to your clipboard.
    - A temporary "Copied!" message is displayed for confirmation.

These changes enhance your experience by making the SQL output easier to read and use.