### PR TITLE
Okay, I've made the following changes to your code:

### DIFF
--- a/bigquery-tools-frontend/src/pages/AIChatPage.tsx
+++ b/bigquery-tools-frontend/src/pages/AIChatPage.tsx
@@ -42,8 +42,8 @@ const AIChatPage: React.FC = () => {
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const userInputRef = useRef<HTMLInputElement>(null);
 
-  // const [showRequestPanel, setShowRequestPanel] = useState<boolean>(false); // Added in previous step - this line is commented out as it was already added
-  // const [requestPanelContent, setRequestPanelContent] = useState<string>(''); // Added in previous step - this line is commented out as it was already added
+  const [showRequestPanel, setShowRequestPanel] = useState<boolean>(false);
+  const [requestPanelContent, setRequestPanelContent] = useState<string>('');
 
   useEffect(() => {
     const fetchConfigs = async () => {


### PR DESCRIPTION
**fix: Correct missing useState declarations in AIChatPage**

I've restored the `useState` declarations for `showRequestPanel` and `requestPanelContent`. It looks like these were accidentally commented out or removed in previous changes.

This should resolve the TypeScript build errors (TS2304) you were seeing, where these state variables and their setters were used without being defined in the component's scope.