### PR TITLE
Fix: Resolve build error related to getApiUrl

### DIFF
--- a/bigquery-tools-frontend/src/config/api.ts
+++ b/bigquery-tools-frontend/src/config/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = '/api'; // Changed from absolute to relative
+export const API_BASE_URL = '/api'; // Changed from absolute to relative
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/bigquery-tools-frontend/src/services/settingsService.ts
+++ b/bigquery-tools-frontend/src/services/settingsService.ts
@@ -1,7 +1,7 @@
-import { getApiUrl } from '../config/api'; // Assuming you have this helper
+import { API_BASE_URL } from '../config/api';
 import { getToken } from './authService'; // For authorization header
 
-const API_URL = getApiUrl();
+const API_URL = API_BASE_URL;
 
 export interface GeminiApiKeyResponse {
   api_key?: string;


### PR DESCRIPTION
Corrects a build error (TS2614) caused by an incorrect import of `getApiUrl` in `settingsService.ts`.

- Modifies `config/api.ts` to export the `API_BASE_URL` constant.
- Updates `settingsService.ts` to import and use `API_BASE_URL` directly, instead of the non-existent `getApiUrl` function.