### PR TITLE
Fix: Correct GeminiService instantiation

### DIFF
--- a/backend/app/routes/api.py
+++ b/backend/app/routes/api.py
@@ -486,8 +486,8 @@ def generate_sql_from_natural_language():
     #     return jsonify(message="AI service is not configured."), 500
 
     try:
-        # gemini_service = GeminiService(api_key=gemini_api_key) # Proper way
-        gemini_service = GeminiService(api_key=temp_gemini_api_key) # Using temporary key
+        # gemini_service = GeminiService() # Proper way
+        gemini_service = GeminiService() # Using temporary key
     except ValueError as ve: # If API key is missing in GeminiService init
         current_app.logger.error(f"GeminiService initialization error: {ve}")
         return jsonify(message=f"AI service initialization error: {ve}"), 500


### PR DESCRIPTION
Removes the unexpected 'api_key' keyword argument from the GeminiService constructor call in api.py.

The GeminiService is designed to fetch the API key from the database itself, so passing it during instantiation was causing a TypeError. This change corrects the instantiation to align with the service's design.

This fix is expected to resolve the backend error: "TypeError: GeminiService.__init__() got an unexpected keyword argument 'api_key'" and the associated frontend error:
"Failed to generate SQL: undefined"